### PR TITLE
Select output fields

### DIFF
--- a/src/swio_calculator.F90
+++ b/src/swio_calculator.F90
@@ -336,6 +336,8 @@ contains
 
     end if
 
+    this % outputCount = this % outputCount + item
+
     if (btest(verbosity,8)) then
       if (item == 0) then
         call ESMF_LogWrite(trim(name)//": "//trim(pName)//": compute: None", &

--- a/src/swio_data.F90
+++ b/src/swio_data.F90
@@ -20,11 +20,13 @@ module swio_data
 
   type SWIO_Data_T
     integer                 :: fieldCount
+    integer                 :: outputCount
     logical                 :: geoReference
     character(ESMF_MAXSTR)  :: gridType
     character(ESMF_MAXSTR)  :: filePrefix
     character(ESMF_MAXSTR)  :: fileSuffix
     type(SWIO_Pair_T), pointer :: meta(:)
+    type(SWIO_Pair_T), pointer :: output(:)
     type(SWIO_Task_T), pointer :: task(:)
     class(COMIO_T),    pointer :: io
   end type


### PR DESCRIPTION
This PR add the ability to explicitly select which imported fields should be included in SWIO's output files, and to optionally set a custom output variable name for each of them.

Requested output fields (and their corresponding output name, if provided) are listed in the SWIO resource file under the new `output_fields::` table. The example below shows only two fields being added to the SWIO output: `height`, written as variable`wam_height_levels`, and `temp_neutral` (written as `temp_neutral`):

```
import_fields::
    height
    temp_neutral
    eastward_wind_neutral
    northward_wind_neutral
    upward_wind_neutral
    O_Density
    O2_Density
    N2_Density
    thermosphere_mass_density
    thermosphere_mean_molecular_mass
::

output_fields::
    height        wam_height_levels
    temp_neutral
::
```