### PR TITLE
SWPC products

### DIFF
--- a/src/swio.F90
+++ b/src/swio.F90
@@ -764,7 +764,7 @@ module SWIO
     integer                    :: comm
     integer                    :: iofmt
     integer                    :: verbosity
-    character(len=ESMF_MAXSTR) :: ioFormat
+    character(len=ESMF_MAXSTR) :: ioOption
     character(len=ESMF_MAXSTR) :: name, svalue
     type(ESMF_Config)          :: config
     type(ESMF_VM)              :: vm
@@ -825,6 +825,43 @@ module SWIO
         file=__FILE__)) &
         return  ! bail out
 
+      ! get file create mode
+      call ESMF_ConfigGetAttribute(config, svalue, &
+        label="output_create_mode:", default="clobber", rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__)) &
+        return  ! bail out
+      ioOption = ESMF_UtilStringLowerCase(svalue, rc=rc)
+      if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__)) &
+        return  ! bail out
+
+      ! convert text to COMIO I/O selector
+      select case (trim(ioOption))
+        case ("clobber")
+          this % cmode = "c"
+        case ("preserve-links")
+          this % cmode = "c+"
+        case default
+          call ESMF_LogSetError(rcToCheck=ESMF_RC_VAL_OUTOFRANGE, &
+            msg="Invalid file create mode", &
+            line=__LINE__, &
+            file=__FILE__, &
+            rcToReturn=rc)
+          return  ! bail out
+      end select
+      if (btest(verbosity,8)) then
+        call ESMF_LogWrite(trim(name)//": "//rName &
+          //": Output create mode set to: "//trim(ioOption), &
+          ESMF_LOGMSG_INFO, rc=rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__)) &
+          return  ! bail out
+      end if
+
       ! get I/O format
       call ESMF_ConfigGetAttribute(config, svalue, &
         label="output_format:", default="none", rc=rc)
@@ -832,14 +869,14 @@ module SWIO
         line=__LINE__,  &
         file=__FILE__)) &
         return  ! bail out
-      ioFormat = ESMF_UtilStringLowerCase(svalue, rc=rc)
+      ioOption = ESMF_UtilStringLowerCase(svalue, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__,  &
         file=__FILE__)) &
         return  ! bail out
 
       ! convert text to COMIO I/O selector
-      select case (trim(ioFormat))
+      select case (trim(ioOption))
         case ("hdf5")
           iofmt = COMIO_FMT_HDF5
           this % fileSuffix = "hd5"
@@ -883,7 +920,7 @@ module SWIO
       if (btest(verbosity,8)) then
         call ESMF_LogWrite(trim(name)//": "//rName//": I/O initialized (COMIO)"&
           //" - Writing to: "//trim(this % filePrefix)//"_YYYYMMDD_hhmmss."&
-          //trim(this % fileSuffix)//" "//trim(ioFormat)//" files", &
+          //trim(this % fileSuffix)//" "//trim(ioOption)//" files", &
           ESMF_LOGMSG_INFO, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__,  &
@@ -898,17 +935,17 @@ module SWIO
         line=__LINE__,  &
         file=__FILE__)) &
         return  ! bail out
-      ioFormat = ESMF_UtilStringLowerCase(svalue, rc=rc)
+      ioOption = ESMF_UtilStringLowerCase(svalue, rc=rc)
       if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
         line=__LINE__,  &
         file=__FILE__)) &
         return  ! bail out
 
-      select case (trim(ioFormat))
+      select case (trim(ioOption))
         case ("integer")
           call this % io % writeas(1)
           if (this % io % err % check(&
-            msg="Failure setting output datatype to "//trim(ioFormat), &
+            msg="Failure setting output datatype to "//trim(ioOption), &
             line=__LINE__,  &
             file=__FILE__)) then
             call ESMF_LogSetError(ESMF_RC_OBJ_INIT, msg=ESMF_LOGERR_PASSTHRU, &
@@ -919,7 +956,7 @@ module SWIO
         case ("float")
           call this % io % writeas(1.)
           if (this % io % err % check(&
-            msg="Failure setting output datatype to "//trim(ioFormat), &
+            msg="Failure setting output datatype to "//trim(ioOption), &
             line=__LINE__,  &
             file=__FILE__)) then
             call ESMF_LogSetError(ESMF_RC_OBJ_INIT, msg=ESMF_LOGERR_PASSTHRU, &
@@ -930,7 +967,7 @@ module SWIO
         case ("double")
           call this % io % writeas(1.d0)
           if (this % io % err % check(&
-            msg="Failure setting output datatype to "//trim(ioFormat), &
+            msg="Failure setting output datatype to "//trim(ioOption), &
             line=__LINE__,  &
             file=__FILE__)) then
             call ESMF_LogSetError(ESMF_RC_OBJ_INIT, msg=ESMF_LOGERR_PASSTHRU, &
@@ -942,14 +979,14 @@ module SWIO
           ! do nothing
         case default
           call ESMF_LogSetError(ESMF_RC_NOT_VALID, &
-            msg="Unsupported datatype: "//trim(ioFormat), &
+            msg="Unsupported datatype: "//trim(ioOption), &
             line=__LINE__, &
             file=__FILE__)
           return  ! bail out
       end select
       if (btest(verbosity,8)) then
         call ESMF_LogWrite(trim(name)//": "//rName &
-          //": Output datatype set to: "//trim(ioFormat), &
+          //": Output datatype set to: "//trim(ioOption), &
           ESMF_LOGMSG_INFO, rc=rc)
         if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__,  &

--- a/src/swio.F90
+++ b/src/swio.F90
@@ -272,6 +272,7 @@ module SWIO
     this % gridType     = ""
     this % filePrefix   = ""
     this % fileSuffix   = ""
+    nullify(this % mask)
     nullify(this % meta)
     nullify(this % output)
     nullify(this % task)
@@ -810,6 +811,14 @@ module SWIO
 
     ! parse metadata if provided
     call SWIO_MetadataParse(gcomp, label="output_metadata::", &
+      phaseName=rName, rc=rc)
+    if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__, &
+      file=__FILE__)) &
+      return  ! bail out
+
+    ! parse masking field
+    call SWIO_OutputMaskParse(gcomp, label="import_mask_field:", &
       phaseName=rName, rc=rc)
     if (ESMF_LogFoundError(rcToCheck=rc, msg=ESMF_LOGERR_PASSTHRU, &
       line=__LINE__, &

--- a/src/swio_calculator.F90
+++ b/src/swio_calculator.F90
@@ -14,11 +14,12 @@ module swio_calculator
     integer                :: rank
   end type
 
-  type(SWIO_Math_T), parameter :: mathTable(3) = &
+  type(SWIO_Math_T), parameter :: mathTable(4) = &
     (/ &
-      SWIO_Math_T( "column_integrate",  1, 0, 1, 2 ),  &
-      SWIO_Math_T( "column_max_point",  1, 0, 2, 2 ),  &
-      SWIO_Math_T( "column_max_region", 1, 2, 2, 2 )   &
+      SWIO_Math_T( "column_integrate",   1, 0, 1, 2 ),  &
+      SWIO_Math_T( "column_max_point",   1, 0, 2, 2 ),  &
+      SWIO_Math_T( "column_max_region",  1, 2, 2, 2 ),  &
+      SWIO_Math_T( "column_interpolate", 2, 1, 1, 2 )   &
     /)
 
   private
@@ -365,21 +366,32 @@ contains
     select case (trim(task % operation))
       case ("column_integrate")
         call columnIntegrate(task, rc=localrc)
-        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        if (ESMF_LogFoundError(rcToCheck=localrc, &
+          msg="Failure in function: "//task % operation, &
           line=__LINE__,  &
           file=__FILE__,  &
           rcToReturn=rc)) &
           return  ! bail out
       case ("column_max_point")
         call columnMaxLoc(task, rc=localrc)
-        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        if (ESMF_LogFoundError(rcToCheck=localrc, &
+          msg="Failure in function: "//task % operation, &
           line=__LINE__,  &
           file=__FILE__,  &
           rcToReturn=rc)) &
           return  ! bail out
       case ("column_max_region")
         call columnMaxLocRegion(task, rc=localrc)
-        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        if (ESMF_LogFoundError(rcToCheck=localrc, &
+          msg="Failure in function: "//task % operation, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) &
+          return  ! bail out
+      case ("column_interpolate")
+        call columnInterpolate(task, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, &
+          msg="Failure in function: "//task % operation, &
           line=__LINE__,  &
           file=__FILE__,  &
           rcToReturn=rc)) &
@@ -1158,5 +1170,240 @@ contains
     end do
 
   end subroutine columnMaxLocRegion
+
+  subroutine columnInterpolate(task, rc)
+    type(SWIO_Task_T), intent(inout) :: task
+    integer, optional, intent(out)   :: rc
+
+    ! -- local variables
+    integer :: localrc
+    integer :: dimCount, rank
+    integer :: localDe, localDeCount
+    integer :: i, j
+    integer, dimension(3) :: lb, ub
+    logical :: isValid
+    real(ESMF_KIND_R8), dimension(1)              :: xd, yd
+    real(ESMF_KIND_R8), dimension(:),     pointer :: x, y
+    real(ESMF_KIND_R8), dimension(:,:),   pointer :: q
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: f, h
+    type(ESMF_Grid)  :: grid
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    ! -- check if arguments are valid
+    isValid = isTaskValid(task, mathTable(4), rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+    if (.not.isValid) then
+      call ESMF_LogSetError(ESMF_RC_ARG_INCOMP, &
+        msg="invalid argument list", &
+        line=__LINE__, &
+        file=__FILE__, &
+        rcToReturn=rc)
+      return  ! bail out
+    end if
+
+    do i = 1, size(task % fieldInp)
+      call ESMF_FieldGet(task % fieldInp(i), grid=grid, dimCount=dimCount, &
+        rank=rank, localDeCount=localDeCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+      call ESMF_GridGet(grid, dimCount=dimCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+      if ((dimCount /= 2) .or. (rank /= 3)) then
+        call ESMF_LogSetError(ESMF_RC_NOT_IMPL, &
+          msg="this function only supports 2D fields with multiple vertical levels", &
+          line=__LINE__, &
+          file=__FILE__, &
+          rcToReturn=rc)
+        return  ! bail out
+      end if
+    end do
+
+    do localDe = 0, localDeCount-1
+      call ESMF_FieldGet(task % fieldInp(1), localDe=localDe, farrayPtr=f, &
+        computationalLBound=lb, computationalUBound=ub, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+      call ESMF_FieldGet(task % fieldInp(2), localDe=localDe, farrayPtr=h, &
+        rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+      call ESMF_FieldGet(task % fieldOut(1), localDe=localDe, farrayPtr=q, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      nullify(x, y)
+
+      xd(1) = task % paramInp(1)
+      q(lb(1):ub(1),lb(2):ub(2)) = 0._ESMF_KIND_R8
+
+      do j = lb(2), ub(2)
+        do i = lb(1), ub(1)
+          x => h(i,j,:)
+          y => f(i,j,:)
+          yd(1) = 0._ESMF_KIND_R8
+          call PolyInterpolate(x, y, xd, yd, 1, localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__,  &
+            file=__FILE__,  &
+            rcToReturn=rc)) &
+            return  ! bail out
+          q(i,j) = yd(1)
+        end do
+      end do
+
+    end do
+
+  end subroutine columnInterpolate
+
+  ! -- Shared auxiliary math functions
+
+  subroutine PolyInterpolate(xs, ys, xd, yd, m, rc)
+    real(ESMF_KIND_R8), dimension(:), intent(in)  :: xs, ys, xd
+    real(ESMF_KIND_R8), dimension(:), intent(out) :: yd
+    integer, intent(in)  :: m
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    integer :: i, j, k, n, np
+    real(ESMF_KIND_R8) :: x, y, dy
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    n = m + 1
+    np = size(xs)
+    do i = 1, size(xd)
+      x = xd(i)
+      y = 0._ESMF_KIND_R8
+      call locate(xs, np, x, j)
+      if (j == np) then
+        y = ys(np)
+      else if (j > 0) then
+        k = min(max(j-(n-1)/2,1), np+1-n)
+        call polint(xs(k:), ys(k:), n, x, y, dy, rc)
+        if (ESMF_LogFoundError(rcToCheck=rc, msg="Error in polint", &
+          line=__LINE__, &
+          file=__FILE__)) &
+          return  ! bail out
+      end if
+      yd(i) = y
+    end do
+
+  end subroutine PolyInterpolate
+
+  ! -- auxiliary numerical subroutines for interpolation/extrapolation from:
+  ! -- W. H. Press, S. A. Teukolsky, W. T. Vetterling, B. P. Flannery,
+  ! -- Numerical Recipes in Fortran 77: The Art of Scientific Computing
+  ! -- (Vol. 1 of Fortran Numerical Recipes), 2nd Ed., Cambridge Univ. Press
+  ! -- 1992
+
+  subroutine locate(xx, n, x, j)
+    implicit none
+    integer, intent(in) :: n
+    real(ESMF_KIND_R8), intent(in) :: x, xx(n)
+    integer, intent(out) :: j
+
+    ! -- local variables
+    integer :: jl, jm, ju
+
+    ! -- begin
+    jl = 0
+    ju = n + 1
+    do while (ju-jl.gt.1)
+      jm = (ju+jl)/2
+      if ((xx(n).ge.xx(1)).eqv.(x.ge.xx(jm))) then
+        jl = jm
+      else
+        ju = jm
+      end if
+    end do
+    if (x.eq.xx(1)) then
+      j = 1
+    else if (x.eq.xx(n)) then
+      j = n - 1
+    else
+      j = jl
+    end if
+
+  end subroutine locate
+
+  subroutine polint(xa, ya, n, x, y, dy, rc)
+
+    implicit none
+
+    integer, intent(in) :: n
+    real(ESMF_KIND_R8),    intent(in) :: xa(n), ya(n)
+    real(ESMF_KIND_R8),    intent(in) :: x
+    real(ESMF_KIND_R8),   intent(out) :: y, dy
+    integer, intent(out) :: rc
+
+    ! -- local variables
+    integer, parameter :: nmax = 10
+    integer :: i, m, ns
+    real(ESMF_KIND_R8) :: den, dif, dift, ho, hp, w
+    real(ESMF_KIND_R8), dimension(nmax) :: c, d
+
+    ! -- begin
+    rc = ESMF_SUCCESS
+
+    ns = 1
+    dif = abs(x - xa(1))
+    do i = 1, n
+      dift = abs(x - xa(i))
+      if (dift < dif) then
+        ns  = i
+        dif = dift
+      end if
+      c(i) = ya(i)
+      d(i) = ya(i)
+    end do
+    y = ya(ns)
+    ns = ns - 1
+    do m = 1, n - 1
+      do i = 1, n - m
+        ho = xa(i)   - x
+        hp = xa(i+m) - x
+        w  = c(i+1)-d(i)
+        den = ho - hp
+        if (den == 0.) then
+          rc = ESMF_FAILURE
+          exit
+        end if
+        den = w / den
+        d(i) = hp * den
+        c(i) = ho * den
+      end do
+      if (2*ns < n - m) then
+        dy = c(ns+1)
+      else
+        dy = d(ns)
+        ns = ns - 1
+      end if
+      y = y + dy
+    end do
+
+  end subroutine polint
 
 end module swio_calculator

--- a/src/swio_data.F90
+++ b/src/swio_data.F90
@@ -25,6 +25,7 @@ module swio_data
     character(ESMF_MAXSTR)  :: gridType
     character(ESMF_MAXSTR)  :: filePrefix
     character(ESMF_MAXSTR)  :: fileSuffix
+    character(2)            :: cmode
     type(SWIO_Pair_T), pointer :: meta(:)
     type(SWIO_Pair_T), pointer :: output(:)
     type(SWIO_Task_T), pointer :: task(:)

--- a/src/swio_data.F90
+++ b/src/swio_data.F90
@@ -13,6 +13,12 @@ module swio_data
     real(ESMF_KIND_R8)          :: scaleFactor
   end type
 
+  type SWIO_Mask_T
+    type(ESMF_Field)   :: field
+    real(ESMF_KIND_R8) :: value
+    real(ESMF_KIND_R8) :: fill
+  end type
+
   type SWIO_Pair_T
     character(ESMF_MAXSTR) :: key
     character(ESMF_MAXSTR) :: value
@@ -26,6 +32,7 @@ module swio_data
     character(ESMF_MAXSTR)  :: filePrefix
     character(ESMF_MAXSTR)  :: fileSuffix
     character(2)            :: cmode
+    type(SWIO_Mask_T), pointer :: mask
     type(SWIO_Pair_T), pointer :: meta(:)
     type(SWIO_Pair_T), pointer :: output(:)
     type(SWIO_Task_T), pointer :: task(:)

--- a/src/swio_methods.F90
+++ b/src/swio_methods.F90
@@ -1235,7 +1235,7 @@ contains
     if (isTimeValid) then
       ! open file
       fileName = trim(this % filePrefix) // "." // timeStamp // "." // trim(this % fileSuffix)
-      call this % io % open(fileName, "c")
+      call this % io % open(fileName, this % cmode)
       if (this % io % err % check(msg="Failure creating file "//trim(fileName), &
         line=__LINE__,  &
         file=__FILE__)) then

--- a/src/swio_methods.F90
+++ b/src/swio_methods.F90
@@ -20,6 +20,7 @@ module swio_methods
   public :: SWIO_MeshWriteCoord
   public :: SWIO_MetadataParse
   public :: SWIO_OutputFieldsParse
+  public :: SWIO_OutputMaskParse
   public :: SWIO_Output
 
 
@@ -53,6 +54,10 @@ module swio_methods
 
   interface SWIO_OutputFieldsParse
     module procedure OutputFieldsParse
+  end interface
+
+  interface SWIO_OutputMaskParse
+    module procedure OutputMaskParse
   end interface
 
   interface SWIO_Output
@@ -828,6 +833,83 @@ contains
 
   end subroutine FieldGetTimeStamp
 
+  subroutine FieldSetMask(field, maskField, maskValue, fillValue, rc)
+    type(ESMF_Field)                :: field
+    type(ESMF_Field),   intent(in)  :: maskField
+    real(ESMF_KIND_R8), intent(in)  :: maskValue
+    real(ESMF_KIND_R8), intent(in)  :: fillValue
+    integer, optional,  intent(out) :: rc
+
+    ! -- local variables
+    integer :: localrc
+    integer :: l, localDe, localDeCount, mrank, rank
+    real(ESMF_KIND_R8), dimension(:,:),   pointer :: mptr2d
+    real(ESMF_KIND_R8), dimension(:,:),   pointer :: fptr2d
+    real(ESMF_KIND_R8), dimension(:,:,:), pointer :: fptr3d
+
+    ! -- begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    call ESMF_FieldGet(field, localDeCount=localDeCount, rank=rank, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    call ESMF_FieldGet(maskField, rank=mrank, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+       line=__LINE__,  &
+       file=__FILE__,  &
+       rcToReturn=rc)) &
+       return  ! bail out
+
+    do localDe = 0, localDeCount-1
+      nullify(mptr2d)
+      select case (mrank)
+        case (2)
+          call ESMF_FieldGet(maskField, localDe=localDe, farrayPtr=mptr2d, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__,  &
+            file=__FILE__,  &
+            rcToReturn=rc)) return  ! bail out
+        case (3)
+          nullify(fptr3d)
+          call ESMF_FieldGet(maskField, localDe=localDe, farrayPtr=fptr3d, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__,  &
+            file=__FILE__,  &
+            rcToReturn=rc)) return  ! bail out
+          mptr2d => fptr3d(:,:,lbound(fptr3d,dim=3))
+      end select
+      if (associated(mptr2d)) then
+        select case (rank)
+          case (2)
+            nullify(fptr2d)
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=fptr2d, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__,  &
+              file=__FILE__,  &
+              rcToReturn=rc)) return  ! bail out
+            where (mptr2d == maskValue) fptr2d = fillValue
+          case (3)
+            nullify(fptr3d)
+            call ESMF_FieldGet(field, localDe=localDe, farrayPtr=fptr3d, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__,  &
+              file=__FILE__,  &
+              rcToReturn=rc)) return  ! bail out
+            ! -- set mask from top to bottom to prevent issues when mask
+            ! -- and masked fields are the same object
+            do l = ubound(fptr3d,dim=3), lbound(fptr3d,dim=3), -1
+              where (mptr2d == maskValue) fptr3d(:,:,l) = fillValue
+            end do
+        end select
+      end if
+    end do
+
+  end subroutine FieldSetMask
+
   function GridCreateLatLon(gcomp, rc) result (grid)
     type(ESMF_GridComp)            :: gcomp
     integer, optional, intent(out) :: rc
@@ -1128,7 +1210,6 @@ contains
     integer                             :: dimCount
     integer                             :: fieldCount
     integer                             :: itemCount
-    integer                             :: rank
     integer                             :: verbosity
     character(len=15)                   :: timeStamp
     character(len=ESMF_MAXSTR)          :: name
@@ -1138,6 +1219,7 @@ contains
     character(len=ESMF_MAXSTR), pointer :: standardNameList(:)
     type(ESMF_Array)                    :: array
     type(ESMF_Field)                    :: field
+    type(ESMF_Field)                    :: maskField
     type(ESMF_GeomType_Flag)            :: geomtype
     type(ESMF_Grid)                     :: grid
     type(ESMF_Mesh)                     :: mesh
@@ -1264,17 +1346,70 @@ contains
         rcToReturn=rc)) &
         return  ! bail out
 
-      ! write select output fields
-      itemCount = 0
-      if (associated(this % output)) itemCount = size(this % output)
-      do item = 1, itemCount
-        call ESMF_StateGet(importState, trim(this % output(item) % key), field, rc=localrc)
+      ! mask output fields using fill value
+      if (associated(this % mask)) then
+        itemCount = 0
+        if (associated(this % output)) itemCount = size(this % output)
+        do item = 1, itemCount
+          call ESMF_StateGet(importState, trim(this % output(item) % key), &
+            field, rc=localrc)
+          if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__,  &
+            file=__FILE__,  &
+            rcToReturn=rc)) &
+            return  ! bail out
+          if (field /= this % mask % field) then
+            call FieldSetMask(field, this % mask % field, this % mask % value, &
+              this % mask % fill, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__,  &
+              file=__FILE__,  &
+              rcToReturn=rc)) &
+              return  ! bail out
+          end if
+        end do
+        itemCount = 0
+        if (associated(this % task)) itemCount = size(this % task)
+        do item = 1, itemCount
+          fieldCount = 0
+          if (associated(this % task(item) % fieldOut)) &
+            fieldCount = size(this % task(item) % fieldOut)
+          do i = 1, fieldCount
+            call FieldSetMask(this % task(item) % fieldOut(i), this % mask % field, &
+              this % mask % value, this % mask % fill, rc=localrc)
+            if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+              line=__LINE__,  &
+              file=__FILE__,  &
+              rcToReturn=rc)) &
+              return  ! bail out
+          end do
+        end do
+        call FieldSetMask(this % mask % field, this % mask % field, &
+          this % mask % value, this % mask % fill, rc=localrc)
         if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__,  &
           file=__FILE__,  &
           rcToReturn=rc)) &
           return  ! bail out
-        call ESMF_FieldGet(field, rank=rank, rc=localrc)
+        call this % io % fill(this % mask % fill)
+        if (this % io % err % check(msg="Failure setting fill value in file " &
+          //trim(fileName), &
+          line=__LINE__,  &
+          file=__FILE__)) then
+          call ESMF_LogSetError(ESMF_RC_FILE_CREATE, msg=ESMF_LOGERR_PASSTHRU, &
+            line=__LINE__, &
+            file=__FILE__,  &
+            rcToReturn=rc)
+           return  ! bail out
+        end if
+      end if
+
+      ! write select output fields
+      itemCount = 0
+      if (associated(this % output)) itemCount = size(this % output)
+
+      do item = 1, itemCount
+        call ESMF_StateGet(importState, trim(this % output(item) % key), field, rc=localrc)
         if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
           line=__LINE__,  &
           file=__FILE__,  &
@@ -1731,5 +1866,168 @@ contains
     end if
 
   end subroutine OutputFieldsParse
+
+  subroutine OutputMaskParse(gcomp, label, phaseName, rc)
+    type(ESMF_GridComp)                     :: gcomp
+    character(len=*),           intent(in)  :: label
+    character(len=*), optional, intent(in)  :: phaseName
+    integer,          optional, intent(out) :: rc
+
+    ! local variables
+    logical                             :: isPresent
+    integer                             :: localrc, stat
+    integer                             :: verbosity
+    integer                             :: dimCount
+    character(len=ESMF_MAXSTR)          :: name
+    character(len=ESMF_MAXSTR)          :: pName
+    character(len=ESMF_MAXSTR)          :: fieldName
+    character(len=ESMF_MAXSTR)          :: msgString
+    type(ESMF_Config)                   :: config
+    type(ESMF_Field)                    :: field
+    type(ESMF_Grid)                     :: grid
+    type(ESMF_State)                    :: importState
+    type(SWIO_InternalState_T)          :: is
+    type(SWIO_Data_T), pointer          :: this
+
+    ! begin
+    if (present(rc)) rc = ESMF_SUCCESS
+
+    pName = "OutputMaskParse"
+    if (present(phaseName)) pName = phaseName
+
+    ! get component's info
+    call NUOPC_CompGet(gcomp, name=name, verbosity=verbosity, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    ! get component's internal state
+    call ESMF_GridCompGetInternalState(gcomp, is, localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+    this => is % wrap
+
+    if (trim(this % gridType) == "none") then
+      if (btest(verbosity,8)) then
+        call ESMF_LogWrite(trim(name)//": "//trim(pName)//&
+          ": Masking only available for local 2D grids", &
+          ESMF_LOGMSG_WARNING, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) &
+          return  ! bail out
+      end if
+      return
+    end if
+
+    if (this % fieldCount == 0) then
+      if (btest(verbosity,8)) then
+        call ESMF_LogWrite(trim(name)//": "//trim(pName)//": No input fields", &
+          ESMF_LOGMSG_INFO, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) &
+          return  ! bail out
+      end if
+      return
+    end if
+
+    ! get component's configuration
+    call ESMF_GridCompGet(gcomp, config=config, importState=importState, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    ! look for compute field table
+    call ESMF_ConfigFindLabel(config, label, isPresent=isPresent, rc=localrc)
+    if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+      line=__LINE__,  &
+      file=__FILE__,  &
+      rcToReturn=rc)) &
+      return  ! bail out
+
+    if (isPresent) then
+
+      ! - get mask field name
+      call ESMF_ConfigGetAttribute(config, fieldName, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      ! -- get field
+      call ESMF_StateGet(importState, trim(fieldName), field, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      call ESMF_FieldGet(field, grid=grid, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      call ESMF_GridGet(grid, dimCount=dimCount, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      if (dimCount /= 2) return
+
+      allocate(this % mask, stat=stat)
+      if (ESMF_LogFoundAllocError(statusToCheck=stat, &
+        msg="Unable to allocate memory", &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      this % mask % field = field
+
+      ! - get mask value
+      call ESMF_ConfigGetAttribute(config, this % mask % value, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      ! - get fill value
+      call ESMF_ConfigGetAttribute(config, this % mask % fill, rc=localrc)
+      if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+        line=__LINE__,  &
+        file=__FILE__,  &
+        rcToReturn=rc)) &
+        return  ! bail out
+
+      if (btest(verbosity,8)) then
+        write(msgString,'(a,": ",a,": masking: fill with ",g0.1," where ",a," == ",g0.1)') &
+          trim(name), trim(pName), this % mask % fill, trim(fieldName), this % mask % value
+        call ESMF_LogWrite(trim(msgString), ESMF_LOGMSG_INFO, rc=localrc)
+        if (ESMF_LogFoundError(rcToCheck=localrc, msg=ESMF_LOGERR_PASSTHRU, &
+          line=__LINE__,  &
+          file=__FILE__,  &
+          rcToReturn=rc)) &
+          return  ! bail out
+      end if
+
+    end if
+
+  end subroutine OutputMaskParse
 
 end module swio_methods


### PR DESCRIPTION
This PR introduces the following updates:

- Computation of column O/N2 ratio and neutral density at the ISS average orbital altitude

-  An optional `output_create_mode:` keyword to select the following file create modes in the SWIO resource file:
     - `clobber`, to overwrite existing output files (default)
     - `preserve-links`, to prevent overwriting links to empty file targets
 
    This feature requires COMIO version 0.0.4.

-  The ability to set a custom `_FillValue` for unmapped points in output fields based on a user-selected imported field and a chosen value. This information is provided through the a new configuration keyword (`import_mask_field:`), which requires 3 arguments:
    
    ```import_mask_field: <field_name>  <field_value>  <_FillValue>```
    
    This feature requires COMIO version 0.0.5.

Addresses GSMWAM-IPE issues [#26](https://github.com/NOAA-SWPC/GSMWAM-IPE/issues/26), [#38](https://github.com/NOAA-SWPC/GSMWAM-IPE/issues/38), and [#39](https://github.com/NOAA-SWPC/GSMWAM-IPE/issues/39).
